### PR TITLE
protein class loads go terms from uniprot or a file

### DIFF
--- a/manas_cafa5/protein.py
+++ b/manas_cafa5/protein.py
@@ -1,0 +1,68 @@
+import xml.parsers.expat as xml_parser
+import requests
+import re
+
+class Protein:
+    def __init__(self, name):
+        self.name = name
+        self.terms = None
+
+    def load_uniprot(self):
+        self.load_url(f'https://rest.uniprot.org/uniprotkb/{self.name}.xml')
+
+    def load_url(self, url):
+        data = self._fetch_xml_url(url)
+        self.terms = Protein.parse_xml(data)
+
+    def load_file(self, file):
+        data = open(file, encoding='utf-8').read()
+        self.terms = Protein.parse_xml(data)
+
+    def _fetch_xml_url(self, url):
+        r = requests.get(url)
+        if r.status_code != 200:
+            raise RuntimeError(f'unexpected status code fetching xml for {self.name}: {r.status_code}')
+        ctype = r.headers.get('content-type')
+        if ctype == None:
+            raise RuntimeError('content-type header not sent')
+        if re.match(r'^(application|text)/xml\s*(;|$)', ctype) == None:
+            raise RuntimeError(('unexpected content-type: expected application/xml or text/xml, '
+                f'received: {r.headers["content-type"]}'))
+        return r.text
+
+    def go_terms(self):
+        if self.terms == None:
+            self.load_uniprot()
+        return self.terms.get('go')
+
+    def parse_xml(xml_data):
+        cursor = {
+            'terms': { 'go': [] },
+            'dbref': None,
+        }
+
+        def start_element(cursor, name, attrs):
+            atype = attrs.get('type')
+            dbref = cursor.get('dbref')
+            if dbref != None and name == 'property' and atype != None:
+                dbref['properties'][atype] = attrs.get('value')
+            if name == 'dbReference' and atype == 'GO':
+                dbref = {
+                    'id': attrs.get('id'),
+                    'properties': {},
+                }
+                cursor['dbref'] = dbref
+                cursor['terms']['go'].append(dbref)
+
+        def end_element(name):
+            pass
+        def char_data(data):
+            pass
+
+        p = xml_parser.ParserCreate()
+        p.StartElementHandler = lambda name, attrs: start_element(cursor, name, attrs)
+        p.EndElementHandler = end_element
+        p.CharacterDataHandler = char_data
+        p.Parse(xml_data)
+
+        return cursor.get('terms')


### PR DESCRIPTION
This patch fleshes out the implementation from #8 adding a Protein class that loads GO terms from uniprot (or a file):

``` python
from manas_cafa5.protein import Protein
p = Protein('P68510')
print(p.go_terms())
```

---

```
[{'id': 'GO:0150048', 'properties': {'term': 'C:cerebellar granule cell to Purkinje cell synapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}}, {'id': 'GO:0005737', 'properties': {'term': 'C:cytoplasm', 'evidence': 'ECO:0000314', 'project': 'MGI'}}, {'id': 'GO:0005829', 'properties': {'term': 'C:cytosol', 'evidence': 'ECO:0000304', 'project': 'Reactome'}}, {'id': 'GO:0098978', 'properties': {'term': 'C:glutamatergic synapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}}, {'id': 'GO:0014704', 'properties': {'term': 'C:intercalated disc', 'evidence': 'ECO:0000305', 'project': 'BHF-UCL'}}, {'id': 'GO:0005886', 'properties': {'term': 'C:plasma membrane', 'evidence': 'ECO:0000266', 'project': 'MGI'}}, {'id': 'GO:0098793', 'properties': {'term': 'C:presynapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}}, {'id': 'GO:0045202', 'properties': {'term': 'C:synapse', 'evidence': 'ECO:0000266', 'project': 'MGI'}}, {'id': 'GO:0003779', 'properties': {'term': 'F:actin binding', 'evidence': 'ECO:0000314', 'project': 'ProtInc'}}, {'id': 'GO:0019899', 'properties': {'term': 'F:enzyme binding', 'evidence': 'ECO:0000266', 'project': 'MGI'}}, {'id': 'GO:0042802', 'properties': {'term': 'F:identical protein binding', 'evidence': 'ECO:0000266', 'project': 'MGI'}}, {'id': 'GO:0035259', 'properties': {'term': 'F:nuclear glucocorticoid receptor binding', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}}, {'id': 'GO:0019904', 'properties': {'term': 'F:protein domain specific binding', 'evidence': 'ECO:0000314', 'project': 'MGI'}}, {'id': 'GO:0046982', 'properties': {'term': 'F:protein heterodimerization activity', 'evidence': 'ECO:0000266', 'project': 'MGI'}}, {'id': 'GO:0017080', 'properties': {'term': 'F:sodium channel regulator activity', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}}, {'id': 'GO:0044325', 'properties': {'term': 'F:transmembrane transporter binding', 'evidence': 'ECO:0000353', 'project': 'BHF-UCL'}}, {'id': 'GO:0007010', 'properties': {'term': 'P:cytoskeleton organization', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}}, {'id': 'GO:0006713', 'properties': {'term': 'P:glucocorticoid catabolic process', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}}, {'id': 'GO:0042921', 'properties': {'term': 'P:glucocorticoid receptor signaling pathway', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}}, {'id': 'GO:0006886', 'properties': {'term': 'P:intracellular protein transport', 'evidence': 'ECO:0000314', 'project': 'MGI'}}, {'id': 'GO:0086010', 'properties': {'term': 'P:membrane depolarization during action potential', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}}, {'id': 'GO:0043066', 'properties': {'term': 'P:negative regulation of apoptotic process', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}}, {'id': 'GO:0050774', 'properties': {'term': 'P:negative regulation of dendrite morphogenesis', 'evidence': 'ECO:0000314', 'project': 'MGI'}}, {'id': 'GO:0045893', 'properties': {'term': 'P:positive regulation of DNA-templated transcription', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}}, {'id': 'GO:0099171', 'properties': {'term': 'P:presynaptic modulation of chemical synaptic transmission', 'evidence': 'ECO:0000314', 'project': 'SynGO'}}, {'id': 'GO:0007088', 'properties': {'term': 'P:regulation of mitotic nuclear division', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}}, {'id': 'GO:2000649', 'properties': {'term': 'P:regulation of sodium ion transmembrane transporter activity', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}}, {'id': 'GO:0002028', 'properties': {'term': 'P:regulation of sodium ion transport', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}}, {'id': 'GO:0007165', 'properties': {'term': 'P:signal transduction', 'evidence': 'ECO:0000318', 'project': 'GO_Central', 'entry name': '1433_2', 'match status': '1'}}]
```