### PR TITLE
add pre-baked alphafold url to structure

### DIFF
--- a/manas_cafa5/structure.py
+++ b/manas_cafa5/structure.py
@@ -37,6 +37,9 @@ class Structure:
     def load_pdb(self, name):
         self.load_url(f'ftp://ftp.wwpdb.org//pub/pdb/data/structures/all/pdb/pdb{name}.ent.gz')
 
+    def load_alphafold(self, name):
+        self.load_url(f'https://alphafold.ebi.ac.uk/files/AF-P{name}-F1-model_v4.pdb')
+
     # https://warwick.ac.uk/fac/sci/moac/people/students/peter_cock/python/protein_contact_map/
     def contact_map(self, chain_one, chain_two, threshold):
         model = self.structure[0]


### PR DESCRIPTION
This patch implements #18 by adding a `load_alphafold` method:

```
>> from manas_cafa5.structure import Structure; s=Structure(); s.load_alphafold('01112')
>>> s.get_chain_ids()
['A']
>>> s.contact_map('A', 'A', 0.5)
array([[1., 0., 0., ..., 0., 0., 0.],
       [0., 1., 0., ..., 0., 0., 0.],
       [0., 0., 1., ..., 0., 0., 0.],
       ...,
       [0., 0., 0., ..., 1., 0., 0.],
       [0., 0., 0., ..., 0., 1., 0.],
       [0., 0., 0., ..., 0., 0., 1.]])
```

I added the leading `P` so there is correspondance with the pdb names. I'm not completely sure about how the pdb or alphafold names that contain letters are meant to be capitalized though.