### PR TITLE
refactor protein/structure

### DIFF
--- a/manas_cafa5/structure.py
+++ b/manas_cafa5/structure.py
@@ -5,6 +5,8 @@ from io import StringIO
 from .utils import fetch_url
 import numpy as np
 
+STRUCTURE_TERMS = set([ 'pdb', 'alphafolddb' ])
+
 class Structure:
     def __init__(self, term):
         self.type = term.get('type')


### PR DESCRIPTION
This patch is a big refactor that changes the relationship between proteins and structure based on feedback.

It solves issues #17 and #18.

Now methods in `Protein` return `Structure` objects. The methods are now more general so there is less special about a dbReference for a GO term versus a pdb versus an alphafold.

Here is what using the new refactored code looks like:

```
>>> from manas_cafa5.protein import Protein; p = Protein('p68510'); p.load_file('p68510.xml')
>>> p.get_terms('go')
[<manas_cafa5.Structure id=GO:0150048 type=go properties={'term': 'C:cerebellar granule cell to Purkinje cell synapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}>, <manas_cafa5.Structure id=GO:0005737 type=go properties={'term': 'C:cytoplasm', 'evidence': 'ECO:0000314', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0005829 type=go properties={'term': 'C:cytosol', 'evidence': 'ECO:0000304', 'project': 'Reactome'}>, <manas_cafa5.Structure id=GO:0098978 type=go properties={'term': 'C:glutamatergic synapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}>, <manas_cafa5.Structure id=GO:0014704 type=go properties={'term': 'C:intercalated disc', 'evidence': 'ECO:0000305', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0005886 type=go properties={'term': 'C:plasma membrane', 'evidence': 'ECO:0000266', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0098793 type=go properties={'term': 'C:presynapse', 'evidence': 'ECO:0000314', 'project': 'SynGO'}>, <manas_cafa5.Structure id=GO:0045202 type=go properties={'term': 'C:synapse', 'evidence': 'ECO:0000266', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0003779 type=go properties={'term': 'F:actin binding', 'evidence': 'ECO:0000314', 'project': 'ProtInc'}>, <manas_cafa5.Structure id=GO:0019899 type=go properties={'term': 'F:enzyme binding', 'evidence': 'ECO:0000266', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0042802 type=go properties={'term': 'F:identical protein binding', 'evidence': 'ECO:0000266', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0035259 type=go properties={'term': 'F:nuclear glucocorticoid receptor binding', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}>, <manas_cafa5.Structure id=GO:0019904 type=go properties={'term': 'F:protein domain specific binding', 'evidence': 'ECO:0000314', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0046982 type=go properties={'term': 'F:protein heterodimerization activity', 'evidence': 'ECO:0000266', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0017080 type=go properties={'term': 'F:sodium channel regulator activity', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0044325 type=go properties={'term': 'F:transmembrane transporter binding', 'evidence': 'ECO:0000353', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0007010 type=go properties={'term': 'P:cytoskeleton organization', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}>, <manas_cafa5.Structure id=GO:0006713 type=go properties={'term': 'P:glucocorticoid catabolic process', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}>, <manas_cafa5.Structure id=GO:0042921 type=go properties={'term': 'P:glucocorticoid receptor signaling pathway', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}>, <manas_cafa5.Structure id=GO:0006886 type=go properties={'term': 'P:intracellular protein transport', 'evidence': 'ECO:0000314', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0086010 type=go properties={'term': 'P:membrane depolarization during action potential', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0043066 type=go properties={'term': 'P:negative regulation of apoptotic process', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}>, <manas_cafa5.Structure id=GO:0050774 type=go properties={'term': 'P:negative regulation of dendrite morphogenesis', 'evidence': 'ECO:0000314', 'project': 'MGI'}>, <manas_cafa5.Structure id=GO:0045893 type=go properties={'term': 'P:positive regulation of DNA-templated transcription', 'evidence': 'ECO:0000250', 'project': 'UniProtKB'}>, <manas_cafa5.Structure id=GO:0099171 type=go properties={'term': 'P:presynaptic modulation of chemical synaptic transmission', 'evidence': 'ECO:0000314', 'project': 'SynGO'}>, <manas_cafa5.Structure id=GO:0007088 type=go properties={'term': 'P:regulation of mitotic nuclear division', 'evidence': 'ECO:0000303', 'project': 'ProtInc'}>, <manas_cafa5.Structure id=GO:2000649 type=go properties={'term': 'P:regulation of sodium ion transmembrane transporter activity', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0002028 type=go properties={'term': 'P:regulation of sodium ion transport', 'evidence': 'ECO:0000250', 'project': 'BHF-UCL'}>, <manas_cafa5.Structure id=GO:0007165 type=go properties={'term': 'P:signal transduction', 'evidence': 'ECO:0000318', 'project': 'GO_Central'}>]
>>> p.get_children('go', Protein.build_graph('go-basic.obo'), 2)
[<manas_cafa5.Structure id=GO:1902680 type=go properties={}>, <manas_cafa5.Structure id=GO:0023052 type=go properties={}>, <manas_cafa5.Structure id=GO:0051726 type=go properties={}>, <manas_cafa5.Structure id=GO:0050768 type=go properties={}>, <manas_cafa5.Structure id=GO:0033043 type=go properties={}>, <manas_cafa5.Structure id=GO:0006351 type=go properties={}>, <manas_cafa5.Structure id=GO:0050789 type=go properties={}>, <manas_cafa5.Structure id=GO:0008211 type=go properties={}>, <manas_cafa5.Structure id=GO:0012501 type=go properties={}>, <manas_cafa5.Structure id=GO:0016358 type=go properties={}>, <manas_cafa5.Structure id=GO:0042981 type=go properties={}>, <manas_cafa5.Structure id=GO:0015031 type=go properties={}>, <manas_cafa5.Structure id=GO:0051129 type=go properties={}>, <manas_cafa5.Structure id=GO:0048812 type=go properties={}>, <manas_cafa5.Structure id=GO:0022898 type=go properties={}>, <manas_cafa5.Structure id=GO:0000278 type=go properties={}>, <manas_cafa5.Structure id=GO:0046983 type=go properties={}>, <manas_cafa5.Structure id=GO:0051783 type=go properties={}>, <manas_cafa5.Structure id=GO:0099177 type=go properties={}>, <manas_cafa5.Structure id=GO:0008150 type=go properties={}>, <manas_cafa5.Structure id=GO:0050767 type=go properties={}>, <manas_cafa5.Structure id=GO:1904062 type=go properties={}>, <manas_cafa5.Structure id=GO:0043269 type=go properties={}>, <manas_cafa5.Structure id=GO:0007268 type=go properties={}>, <manas_cafa5.Structure id=GO:0016922 type=go properties={}>, <manas_cafa5.Structure id=GO:0099106 type=go properties={}>, <manas_cafa5.Structure id=GO:0005575 type=go properties={}>, <manas_cafa5.Structure id=GO:0005622 type=go properties={}>, <manas_cafa5.Structure id=GO:0007154 type=go properties={}>, <manas_cafa5.Structure id=GO:0051961 type=go properties={}>, <manas_cafa5.Structure id=GO:0006810 type=go properties={}>, <manas_cafa5.Structure id=GO:0005488 type=go properties={}>, <manas_cafa5.Structure id=GO:0006814 type=go properties={}>, <manas_cafa5.Structure id=GO:0008202 type=go properties={}>, <manas_cafa5.Structure id=GO:0043069 type=go properties={}>, <manas_cafa5.Structure id=GO:0050794 type=go properties={}>, <manas_cafa5.Structure id=GO:0016247 type=go properties={}>, <manas_cafa5.Structure id=GO:0070727 type=go properties={}>, <manas_cafa5.Structure id=GO:0022008 type=go properties={}>, <manas_cafa5.Structure id=GO:0048813 type=go properties={}>, <manas_cafa5.Structure id=GO:0071944 type=go properties={}>, <manas_cafa5.Structure id=GO:0006996 type=go properties={}>, <manas_cafa5.Structure id=GO:0032412 type=go properties={}>, <manas_cafa5.Structure id=GO:0048814 type=go properties={}>, <manas_cafa5.Structure id=GO:0046907 type=go properties={}>, <manas_cafa5.Structure id=GO:0032279 type=go properties={}>, <manas_cafa5.Structure id=GO:0010468 type=go properties={}>, <manas_cafa5.Structure id=GO:0045184 type=go properties={}>, <manas_cafa5.Structure id=GO:0000280 type=go properties={}>, <manas_cafa5.Structure id=GO:0006355 type=go properties={}>, <manas_cafa5.Structure id=GO:0010564 type=go properties={}>, <manas_cafa5.Structure id=GO:0030001 type=go properties={}>, <manas_cafa5.Structure id=GO:0097659 type=go properties={}>, <manas_cafa5.Structure id=GO:0008092 type=go properties={}>, <manas_cafa5.Structure id=GO:1901361 type=go properties={}>, <manas_cafa5.Structure id=GO:0030518 type=go properties={}>, <manas_cafa5.Structure id=GO:0098985 type=go properties={}>, <manas_cafa5.Structure id=GO:0016043 type=go properties={}>, <manas_cafa5.Structure id=GO:0071702 type=go properties={}>, <manas_cafa5.Structure id=GO:0005737 type=go properties={}>, <manas_cafa5.Structure id=GO:0042391 type=go properties={}>, <manas_cafa5.Structure id=GO:0043067 type=go properties={}>, <manas_cafa5.Structure id=GO:0022402 type=go properties={}>, <manas_cafa5.Structure id=GO:0006706 type=go properties={}>, <manas_cafa5.Structure id=GO:0001508 type=go properties={}>, <manas_cafa5.Structure id=GO:0071705 type=go properties={}>, <manas_cafa5.Structure id=GO:0031344 type=go properties={}>, <manas_cafa5.Structure id=GO:1903506 type=go properties={}>, <manas_cafa5.Structure id=GO:0005515 type=go properties={}>, <manas_cafa5.Structure id=GO:0030054 type=go properties={}>, <manas_cafa5.Structure id=GO:0002028 type=go properties={}>, <manas_cafa5.Structure id=GO:0060548 type=go properties={}>, <manas_cafa5.Structure id=GO:0035725 type=go properties={}>, <manas_cafa5.Structure id=GO:0031958 type=go properties={}>, <manas_cafa5.Structure id=GO:0010959 type=go properties={}>, <manas_cafa5.Structure id=GO:0051641 type=go properties={}>, <manas_cafa5.Structure id=GO:0016042 type=go properties={}>, <manas_cafa5.Structure id=GO:0009987 type=go properties={}>, <manas_cafa5.Structure id=GO:1902305 type=go properties={}>, <manas_cafa5.Structure id=GO:0110165 type=go properties={}>, <manas_cafa5.Structure id=GO:0051716 type=go properties={}>, <manas_cafa5.Structure id=GO:0030030 type=go properties={}>, <manas_cafa5.Structure id=GO:0051649 type=go properties={}>, <manas_cafa5.Structure id=GO:0048667 type=go properties={}>, <manas_cafa5.Structure id=GO:0006915 type=go properties={}>, <manas_cafa5.Structure id=GO:0008104 type=go properties={}>, <manas_cafa5.Structure id=GO:0005911 type=go properties={}>, <manas_cafa5.Structure id=GO:0022603 type=go properties={}>, <manas_cafa5.Structure id=GO:0050773 type=go properties={}>, <manas_cafa5.Structure id=GO:0050804 type=go properties={}>, <manas_cafa5.Structure id=GO:0060076 type=go properties={}>, <manas_cafa5.Structure id=GO:0031345 type=go properties={}>, <manas_cafa5.Structure id=GO:0010721 type=go properties={}>, <manas_cafa5.Structure id=GO:0061629 type=go properties={}>, <manas_cafa5.Structure id=GO:0050896 type=go properties={}>, <manas_cafa5.Structure id=GO:0045202 type=go properties={}>, <manas_cafa5.Structure id=GO:0044291 type=go properties={}>, <manas_cafa5.Structure id=GO:0140014 type=go properties={}>, <manas_cafa5.Structure id=GO:0007346 type=go properties={}>, <manas_cafa5.Structure id=GO:0016020 type=go properties={}>, <manas_cafa5.Structure id=GO:1903047 type=go properties={}>, <manas_cafa5.Structure id=GO:0051899 type=go properties={}>, <manas_cafa5.Structure id=GO:0098978 type=go properties={}>, <manas_cafa5.Structure id=GO:1903508 type=go properties={}>]
>>> p.get_terms('alphafolddb')[0].load()
>>> p.get_terms('alphafolddb')[0].contact_map('A','A',1)
array([[1., 0., 0., ..., 0., 0., 0.],
       [0., 1., 0., ..., 0., 0., 0.],
       [0., 0., 1., ..., 0., 0., 0.],
       ...,
       [0., 0., 0., ..., 1., 0., 0.],
       [0., 0., 0., ..., 0., 1., 0.],
       [0., 0., 0., ..., 0., 0., 1.]])
```
