### PR TITLE
ia() and get_parents()

### DIFF
--- a/manas_cafa5/protein.py
+++ b/manas_cafa5/protein.py
@@ -1,4 +1,5 @@
 from .structure import Structure, STRUCTURE_TERMS
+from .utils import ancestors_within_distance
 import xml.parsers.expat as xml_parser
 import requests
 import re
@@ -100,13 +101,13 @@ class Protein:
             for term_id in children
         ]
 
-    def get_parents(self, term_type, graph):
+    def get_parents(self, term_type, graph, max_distance=1):
         terms_list = self.get_terms(term_type)
         terms_set = set([ term['id'] for term in terms_list ])
         parents = reduce(
             lambda terms, term: terms.union({
                 parent
-                for parent in networkx.ancestors(graph, term['id'])
+                for parent in ancestors_within_distance(graph, term['id'], max_distance)
                 if parent not in terms_set
             }),
             terms_list,
@@ -127,8 +128,8 @@ class Protein:
     def go_terms_children(self, graph, max_distance):
         return self.get_children('go', graph, max_distance)
 
-    def go_terms_parents(self, graph):
-        return self.get_parents('go', graph)
+    def go_terms_parents(self, graph, max_distance):
+        return self.get_parents('go', graph, max_distance)
 
     @staticmethod
     def build_graph(url_or_file):

--- a/manas_cafa5/utils.py
+++ b/manas_cafa5/utils.py
@@ -1,5 +1,7 @@
+import networkx
 import requests, ftplib
 from urllib.parse import urlparse
+from functools import reduce
 
 def fetch_url(url):
     if url.find('ftp:') == 0:
@@ -16,3 +18,11 @@ def fetch_url(url):
         if r.status_code != 200:
             raise RuntimeError(f'unexpected status code while fetching {url}:  {r.status_code}')
         return r.content
+
+def ancestors_within_distance(graph, term, max_distance):
+    parents = set([term])
+    for dist in range(1,max_distance+1):
+        for parent in parents:
+            parents = parents.union(networkx.ancestors(graph, parent))
+    parents.discard(term)
+    return parents


### PR DESCRIPTION
This patch adds `ia(term_type, graph)` and `get_parents(term_type, graph)` for #28 based on https://www.kaggle.com/competitions/cafa-5-protein-function-prediction/discussion/405237 (as best as i could interpret this).

Here's what it looks like to use:

```
>>> from manas_cafa5.protein import Protein; p = Protein.from_file('p68510', 'data/p68510.xml'); g = Protein.build_graph('data/go-basic.obo')
>>> p.ia('go',g)
7.111309583204707
```

and this feature can be used for the analysis requested in #28:

```
>>> len(p.go_terms())
29
>>> p.ia('go',g) * len(p.go_terms())
206.2279779129365
```

This patch doesn't implement the jupyter notebook but should make that notebook easier and more clear to compose.